### PR TITLE
use acra-server's master key for acra-writer's private key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
     image: "cossacklabs/acra-keymaker:${ACRA_DOCKER_IMAGE_TAG:-latest}"
     network_mode: "none"
     environment:
-      ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-MElBVnhEeTd3b29JMFVVcnhGMXJPT3BxZUVwWW5wS3E=}
+      ACRA_MASTER_KEY: ${ACRA_SERVER_MASTER_KEY:-UHZ3VUNNeTJ0SEFhbWVjNkt4eDdVYkc2WnNpUTlYa0E=}
     volumes:
       - ./.acrakeys:/keys
     command: >-


### PR DESCRIPTION
acra-writer's keys used to encrypt and decrypt data, and it's private key is encrypted by acra-keymaker using master key. Should be used acra-server's master key for their generation because only acra-server should have access to private decryption keys. acra-connector doesn't work with acra-writer's keys.